### PR TITLE
fix out of range exception when loading non-fully qualified assemblies

### DIFF
--- a/Chef.PowerShell.Wrapper/Chef.PowerShell.Wrapper.cpp
+++ b/Chef.PowerShell.Wrapper/Chef.PowerShell.Wrapper.cpp
@@ -19,7 +19,8 @@ Assembly^ currentDomain_AssemblyResolve(Object^ sender, ResolveEventArgs^ args)
     if (prefix) {
         try
         {
-            String^ finalPath = Path::Combine(prefix, args->Name->Substring(0, args->Name->IndexOf(",")) + ".dll");
+            AssemblyName^ name = gcnew AssemblyName(args->Name);
+            String^ finalPath = Path::Combine(prefix, name->Name + ".dll");
             Assembly^ retval = Assembly::LoadFrom(finalPath);
             return retval;
         }

--- a/habitat-x86/plan.ps1
+++ b/habitat-x86/plan.ps1
@@ -1,6 +1,6 @@
 $pkg_name="chef-powershell-shim-x86"
 $pkg_origin="chef"
-$pkg_version="0.2.0"
+$pkg_version="0.2.1"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@("Apache-2.0")
 $pkg_build_deps=@(

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -1,6 +1,6 @@
 $pkg_name="chef-powershell-shim"
 $pkg_origin="chef"
-$pkg_version="0.2.0"
+$pkg_version="0.2.1"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@("Apache-2.0")
 $pkg_build_deps=@(


### PR DESCRIPTION
The assembly resolver was failing on some assemblies in the GAC. Likely because they were not fully qualified and had no ',' in the assembly name. This uses `AssemblyName` to properly parse the name. This also adds a test which was failing prior to the fix. 