### PR TITLE
fix silent win32 long path errors

### DIFF
--- a/habitat-vs-2019-x86/plan.ps1
+++ b/habitat-vs-2019-x86/plan.ps1
@@ -40,10 +40,10 @@ function Invoke-Unpack {
     # to the console but by this time we have everything we need to proceed.
     7z x "$HAB_CACHE_SRC_PATH/$pkg_filename" -o"$HAB_CACHE_SRC_PATH/$pkg_dirname"
     $opcInstaller = (Get-Content "$HAB_CACHE_SRC_PATH\$pkg_dirname\vs_bootstrapper_d15\vs_setup_bootstrapper.config")[0].Split("=")[-1]
-    Invoke-WebRequest $opcInstaller -Outfile "$HAB_CACHE_SRC_PATH/$pkg_dirname/vs_installer.opc"
-    7z x "$HAB_CACHE_SRC_PATH/$pkg_dirname/vs_installer.opc" -o"$HAB_CACHE_SRC_PATH/$pkg_dirname"
+    Invoke-RestMethod $opcInstaller -Outfile "$HAB_CACHE_SRC_PATH/$pkg_dirname/vs_installer.opc"
+    7z x "$HAB_CACHE_SRC_PATH/$pkg_dirname/vs_installer.opc" -o"$HAB_CACHE_SRC_PATH\$pkg_dirname"
 
-    $installArgs =  "layout --quiet --layout $HAB_CACHE_SRC_PATH/$pkg_dirname --lang en-US --in $HAB_CACHE_SRC_PATH/$pkg_dirname/vs_bootstrapper_d15/vs_setup_bootstrapper.json"
+    $installArgs =  "layout --quiet --layout $HAB_CACHE_SRC_PATH/products --lang en-US --in $HAB_CACHE_SRC_PATH/$pkg_dirname/vs_bootstrapper_d15/vs_setup_bootstrapper.json"
     $components = @(
         "Microsoft.VisualStudio.Workload.MSBuildTools",
         "Microsoft.VisualStudio.Workload.VCTools",
@@ -61,15 +61,15 @@ function Invoke-Unpack {
     $setup = "$HAB_CACHE_SRC_PATH/$pkg_dirname/Contents/resources/app/layout/setup.exe"
     Write-Host "Launching $setup with args: $installArgs"
     Start-Process $setup -ArgumentList $installArgs -Wait
-    Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+    Push-Location $HAB_CACHE_SRC_PATH
     try {
-        Get-ChildItem "$HAB_CACHE_SRC_PATH/$pkg_dirname" -Include *.vsix -Exclude @('*x64*', '*.arm.*') -Recurse | ForEach-Object {
+        Get-ChildItem "$HAB_CACHE_SRC_PATH/products" -Include *.vsix -Exclude @('*x64*', '*.arm.*') -Recurse | ForEach-Object {
             Rename-Item $_ "$_.zip"
-            Expand-Archive "$_.zip" expanded -force
+            Expand-Archive "$_.zip" vst -force
         }
     } finally { Pop-Location }
 }
 
 function Invoke-Install {
-    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_dirname\expanded\Contents" $pkg_prefix -Force -Recurse
+    Copy-Item "$HAB_CACHE_SRC_PATH\vst\Contents" $pkg_prefix -Force -Recurse
 }


### PR DESCRIPTION
Signed-off-by: rishichawda <rishichawda@users.noreply.github.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

visual studio setup was silently failing due to long paths and skipping some visual studio packages. Moving the package extracts one level up and directly inside `HAB_CACHE_SRC_PATH` under `products` and `vst` directory seems to have resolved it. I've tested in local studio and the long path errors are gone for the location I was able to reproduce with the earlier configuration.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
