### PR TITLE
Fix Postbuild Processing issue 

### DIFF
--- a/habitat-win-11-sdk-x64/plan.ps1
+++ b/habitat-win-11-sdk-x64/plan.ps1
@@ -1,4 +1,4 @@
-$pkg_name="windows-11-sdk"
+$pkg_name="windows-11-sdk-x64"
 $pkg_origin="chef"
 $pkg_version="10.0.26100"
 $pkg_description="The Windows 11 SDK for Windows 11,(servicing release 10.0.26100.1742) provides the latest headers, libraries, metadata, and tools for building Windows 11 apps"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Addresses an issue encountered during the postbuild processing step, which failed with the following error:

/usr/local/bundle/gems/faraday-1.10.0/lib/faraday/response/raise_error.rb:22:in `on_complete': the server responded with status 404 (Faraday::ResourceNotFound)

The failure occurred while executing the build process defined in .expeditor/build.habitat.yml. The relevant logs can be found at the following link 
 [Buildkite Log](https://buildkite.com/chef/chef-chef-powershell-shim-pipeline-18-stable-habitat-build/builds/1).

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
