### PR TITLE
Unpin FFI

### DIFF
--- a/chef-powershell/Gemfile
+++ b/chef-powershell/Gemfile
@@ -5,6 +5,8 @@ gem "rspec"
 gem "chefstyle"
 gem "pry"
 
+gem "ffi", ">= 1.15", force_ruby_platform: true
+
 gemspec
 
 group(:development, :test) do

--- a/chef-powershell/Gemfile.lock
+++ b/chef-powershell/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     chef-powershell (18.1.0)
-      ffi (~> 1.15)
+      ffi (>= 1.15)
       ffi-yajl (~> 2.4)
 
 GEM
@@ -63,11 +63,13 @@ GEM
 PLATFORMS
   x64-mingw-ucrt
   x64-mingw32
+  x86_64-linux
 
 DEPENDENCIES
   chef-powershell!
   chefstyle
   fauxhai-ng
+  ffi (>= 1.15)
   pry
   rake
   rspec

--- a/chef-powershell/chef-powershell.gemspec
+++ b/chef-powershell/chef-powershell.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.6"
 
-  spec.add_runtime_dependency "ffi", "~> 1.15"
+  spec.add_runtime_dependency "ffi", ">= 1.15"
   spec.add_runtime_dependency "ffi-yajl", "~> 2.4"
 
   spec.metadata = {


### PR DESCRIPTION
```
$ bundle install
Bundler 2.6.4 is running, but your lockfile was generated with 2.5.18. Installing Bundler 2.5.18 and restarting using that version.
Fetching gem metadata from https://rubygems.org/.
Fetching bundler 2.5.18
Installing bundler 2.5.18
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Fetching rake 13.2.1
Installing rake 13.2.1
Fetching ffi 1.17.0
Fetching libyajl2 2.1.0
Fetching ast 2.4.2
Installing libyajl2 2.1.0 with native extensions
Installing ast 2.4.2
Fetching parallel 1.26.3
Installing parallel 1.26.3
Fetching racc 1.8.1
Installing racc 1.8.1 with native extensions
Installing ffi 1.17.0 with native extensions
Fetching rainbow 3.1.1
Installing rainbow 3.1.1
Fetching regexp_parser 2.9.2
Installing regexp_parser 2.9.2
Fetching rexml 3.3.9
Installing rexml 3.3.9
Fetching ruby-progressbar 1.13.0
Installing ruby-progressbar 1.13.0
Fetching unicode-display_width 2.5.0
Installing unicode-display_width 2.5.0
Fetching coderay 1.1.3
Installing coderay 1.1.3
Fetching diff-lcs 1.5.1
Installing diff-lcs 1.5.1
Fetching net-ssh 7.2.3
Installing net-ssh 7.2.3
Fetching method_source 1.1.0
Installing method_source 1.1.0
Fetching rspec-support 3.13.1
Installing rspec-support 3.13.1
Fetching parser 3.3.5.0
Installing parser 3.3.5.0
Fetching fauxhai-ng 9.3.0
Installing fauxhai-ng 9.3.0
Fetching pry 0.14.2
Installing pry 0.14.2
Fetching rspec-core 3.13.1
Installing rspec-core 3.13.1
Fetching rspec-expectations 3.13.2
Installing rspec-expectations 3.13.2
Fetching rspec-mocks 3.13.1
Installing rspec-mocks 3.13.1
Fetching rubocop-ast 1.32.3
Installing rubocop-ast 1.32.3
Fetching rspec 3.13.0
Installing rspec 3.13.0
Fetching ffi-yajl 2.6.0
Fetching rubocop 1.25.1
Installing ffi-yajl 2.6.0 with native extensions
Installing rubocop 1.25.1
Fetching chefstyle 2.2.3
Installing chefstyle 2.2.3
Bundle complete! 7 Gemfile dependencies, 29 gems now installed.
Gems in the group 'omnibus_package' were not installed.
Bundled gems are installed into `./vendor/bundle`
```
