### PR TITLE
hab auth token; Changed Hab channel from LTS-2024 to base-2025

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ $BUILDKITE_ORGANIZATION_SLUG = 'chef-canary' ]]; then
+  AWS_REGION='us-west-1'
+elif [[ $BUILDKITE_ORGANIZATION_SLUG = 'chef' ]] || [[ $BUILDKITE_ORGANIZATION_SLUG = 'chef-oss' ]]; then
+  AWS_REGION='us-west-2'
+fi
+
+export HAB_AUTH_TOKEN=$(aws ssm get-parameter --name 'habitat-prod-auth-token' --with-decryption --query Parameter.Value --output text --region ${AWS_REGION})

--- a/.expeditor/build_gems.ps1
+++ b/.expeditor/build_gems.ps1
@@ -24,8 +24,8 @@ $env:MSBuildEnableWorkloadResolver = "false"
 
 # setting the channel in this way gets access to the LTS channel and falls back to stable if the plan doesn't live there.
 Write-Output "--- :shovel: Setting the BLDR and REFRESH Channels to LTS"
-$env:HAB_BLDR_CHANNEL="LTS-2024"
-$env:HAB_REFRESH_CHANNEL = "LTS-2024"
+$env:HAB_BLDR_CHANNEL="base-2025"
+$env:HAB_REFRESH_CHANNEL = "base-2025"
 Write-Output "`r"
 
 Write-Output "--- :screwdriver: Installing Habitat via Choco"
@@ -74,7 +74,7 @@ Write-Output "`r"
 
 
 Write-Output "--- :construction: Building 64-bit PowerShell DLLs"
-hab pkg build Habitat --refresh-channel LTS-2024
+hab pkg build Habitat --refresh-channel base-2025 --auth $HAB_AUTH_TOKEN
 if (-not $?) { throw "unable to build"}
 Write-Output "`r"
 

--- a/.expeditor/build_gems.ps1
+++ b/.expeditor/build_gems.ps1
@@ -74,7 +74,7 @@ Write-Output "`r"
 
 
 Write-Output "--- :construction: Building 64-bit PowerShell DLLs"
-hab pkg build Habitat --refresh-channel base-2025 --auth $HAB_AUTH_TOKEN
+hab pkg build Habitat --refresh-channel base-2025
 if (-not $?) { throw "unable to build"}
 Write-Output "`r"
 

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -18,6 +18,8 @@ steps:
         host_os: windows
         image: rubydistros/windows-2019:3.1
         shell: [ "powershell", "-Command" ]
+        environment:
+          - HAB_AUTH_TOKEN
 
 - label: ":windows: pre-build-verify-windows-gem - Ruby 3.4"
   commands:
@@ -28,6 +30,8 @@ steps:
         host_os: windows
         image: rubydistros/windows-2019:3.4
         shell: [ "powershell", "-Command" ]
+        environment:
+          - HAB_AUTH_TOKEN
 
 - label: ":windows: What version of Ruby are we using?"
   command: 


### PR DESCRIPTION
## Description
Addition of Habitat authentication token. Changed the builder and refresh channels from LTS-2024 to base-2025

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
