### PR TITLE
CHEF-27640 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,1 +1,1 @@
-Copyright ©  2018-2025 Chef Software Inc. and/or its subsidiaries or affiliates. All rights reserved.
+Copyright ©  2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All rights reserved.

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright ©  2018-2025 Chef Software Inc. and/or its subsidiaries or affiliates. All rights reserved.

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,1 +1,1 @@
-Copyright ©  2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All rights reserved.
+Copyright © 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,1 +1,1 @@
-Copyright © 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved
+Copyright © 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/Chef.PowerShell/Properties/AssemblyInfo.cs
+++ b/Chef.PowerShell/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Chef.PowerShell")]
-[assembly: AssemblyCopyright("Copyright © Chef Software 2018")]
+[assembly: AssemblyCopyright("Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ your local copy of the source running.
 |                      |                                          |
 |:---------------------|:-----------------------------------------|
 | **Author:**          | Stuart Preston (<stuart@chef.io>)
-| **Copyright:**       | Copyright 20, Chef Software, Inc.
 | **License:**         | Apache License, Version 2.0
 
 ```
@@ -78,3 +77,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+# Copyright
+
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 #
 # Author:: John McCrae (<john.mccrae@progress.com>)
-# Copyright:: Copyright, Chef Software Inc.
+# Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Copyright:: Copyright, Progress Software Inc.
 # License:: Apache License, Version 2.0
 #

--- a/chef-powershell/README.md
+++ b/chef-powershell/README.md
@@ -104,9 +104,7 @@ my_result = powershell_exec!(join_command)
 
 We'd love to have your help developing Chef Infra. See our [Contributing Document](../CONTRIBUTING.md) for more information on getting started.
 
-## License and Copyright
-
-Copyright Chef Software, Inc.
+## License 
 
 ```
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-powershell/Rakefile
+++ b/chef-powershell/Rakefile
@@ -1,6 +1,6 @@
 #
 # Author:: John McCrae (<john.mccrae@progress.com>)
-# Copyright:: Copyright, Chef Software Inc.
+# Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Copyright:: Copyright, Progress Software Inc.
 # License:: Apache License, Version 2.0
 #

--- a/chef-powershell/lib/chef-powershell.rb
+++ b/chef-powershell/lib/chef-powershell.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-powershell/lib/chef-powershell/exceptions.rb
+++ b/chef-powershell/lib/chef-powershell/exceptions.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John McCrae (<john.mccrae@progress.com>)
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-powershell/lib/chef-powershell/powershell.rb
+++ b/chef-powershell/lib/chef-powershell/powershell.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Stuart Preston (<stuart@chef.io>)
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-powershell/lib/chef-powershell/powershell_exec.rb
+++ b/chef-powershell/lib/chef-powershell/powershell_exec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Stuart Preston (<stuart@chef.io>)
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-powershell/lib/chef-powershell/pwsh.rb
+++ b/chef-powershell/lib/chef-powershell/pwsh.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Matt Wrock (<mwrock@chef.io>)
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-powershell/lib/chef-powershell/unicode.rb
+++ b/chef-powershell/lib/chef-powershell/unicode.rb
@@ -1,7 +1,7 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
 # Author:: Seth Chisamore (<schisamo@chef.io>)
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-powershell/lib/chef-powershell/version.rb
+++ b/chef-powershell/lib/chef-powershell/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-powershell/lib/chef-powershell/wide_string.rb
+++ b/chef-powershell/lib/chef-powershell/wide_string.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Jay Mundrawala(<jdm@chef.io>)
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-powershell/spec/unit/powershell_exec_spec.rb
+++ b/chef-powershell/spec/unit/powershell_exec_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Stuart Preston (<stuart@chef.io>)
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-powershell/tasks/dependencies.rb
+++ b/chef-powershell/tasks/dependencies.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-powershell/tasks/rspec.rb
+++ b/chef-powershell/tasks/rspec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John McCrae (<john.mccrae@progress.com>)
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-powershell/tasks/spellcheck.rb
+++ b/chef-powershell/tasks/spellcheck.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2018-2025 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme
- `README.md:65` - adjust-readme
- `chef-powershell/README.md:109` - adjust-readme

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
