### PR TITLE
CHEF-37610: Fix error 126 by registering DLL search directory for Windows PowerShell (.NET 481) path

### DIFF
--- a/chef-powershell/lib/chef-powershell/powershell.rb
+++ b/chef-powershell/lib/chef-powershell/powershell.rb
@@ -21,6 +21,26 @@ require_relative "exceptions"
 require_relative "unicode"
 
 class ChefPowerShell
+  module Kernel32
+    extend FFI::Library
+    ffi_lib "kernel32"
+    attach_function :SetDllDirectoryA, %i{string}, :int
+    attach_function :SetDefaultDllDirectories, %i{uint32}, :int
+    attach_function :AddDllDirectory, %i{pointer}, :pointer
+
+    # https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories
+    LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
+
+    # AddDllDirectory requires a wide (UTF-16LE), null-terminated string (LPCWSTR).
+    # Returns true if the directory was registered successfully.
+    def self.register_search_directory(path)
+      wide_path = (path + "\0").encode("UTF-16LE")
+      ptr = FFI::MemoryPointer.new(:uint8, wide_path.bytesize)
+      ptr.put_bytes(0, wide_path)
+      !(AddDllDirectory(ptr).address == 0)
+    end
+  end
+
   def self.bin_dir
     if ENV["CHEF_POWERSHELL_BIN"] && !ENV["CHEF_POWERSHELL_BIN"].empty?
       return File.expand_path(ENV["CHEF_POWERSHELL_BIN"])
@@ -59,7 +79,27 @@ class ChefPowerShell
       # Every merge into that repo triggers a Habitat build and verification process.
       # There is no mechanism to build a Windows gem file. It has to be done manually running manual_gem_release.ps1
       # Bundle install ensures that the correct architecture binaries are installed into the path.
-      @powershell_dll = File.join(ChefPowerShell.bin_dir, "Chef.PowerShell.Wrapper.dll")
+      bin_dir = ChefPowerShell.bin_dir
+      @powershell_dll = File.join(bin_dir, "Chef.PowerShell.Wrapper.dll")
+
+      # Windows' default LoadLibrary(Ex) search order used by FFI does NOT
+      # include the directory of the DLL being loaded -- FFI loads on Windows
+      # with LOAD_LIBRARY_SEARCH_DEFAULT_DIRS, which only searches the hosting
+      # EXE's directory, System32, and directories registered via
+      # SetDllDirectory/AddDllDirectory (notably *not* PATH or the current
+      # directory). Chef.PowerShell.Wrapper.dll depends on native VC++ runtime
+      # DLLs (vcruntime140.dll, msvcp140.dll, etc.) that live alongside it in
+      # bin_dir, so that directory must be registered explicitly or those
+      # dependent DLLs will fail to resolve (error 126) even though the
+      # wrapper DLL itself loads fine via its absolute path.
+      Kernel32.SetDefaultDllDirectories(Kernel32::LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)
+      raise LoadError, "Failed to register DLL search directory: #{bin_dir}" unless Kernel32.register_search_directory(bin_dir)
+
+      # Retained alongside AddDllDirectory for defense in depth / older Windows
+      # compatibility (AddDllDirectory requires Windows 8+/Server 2012+, or
+      # Windows 7 SP1/Server 2008 R2 SP1 with KB2533623).
+      Kernel32.SetDllDirectoryA(bin_dir)
+
       exec(script, timeout: timeout)
     end
 

--- a/chef-powershell/lib/chef-powershell/pwsh.rb
+++ b/chef-powershell/lib/chef-powershell/pwsh.rb
@@ -17,26 +17,6 @@
 
 class ChefPowerShell
   class Pwsh < ChefPowerShell::PowerShell
-    module Kernel32
-      extend FFI::Library
-      ffi_lib "kernel32"
-      attach_function :SetDllDirectoryA, %i{string}, :int
-      attach_function :SetDefaultDllDirectories, %i{uint32}, :int
-      attach_function :AddDllDirectory, %i{pointer}, :pointer
-
-      # https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories
-      LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
-
-      # AddDllDirectory requires a wide (UTF-16LE), null-terminated string (LPCWSTR).
-      # Returns true if the directory was registered successfully.
-      def self.register_search_directory(path)
-        wide_path = (path + "\0").encode("UTF-16LE")
-        ptr = FFI::MemoryPointer.new(:uint8, wide_path.bytesize)
-        ptr.put_bytes(0, wide_path)
-        !(AddDllDirectory(ptr).address == 0)
-      end
-    end
-
     # Run a command under pwsh (powershell core) via FFI
     # This implementation requires the managed dll, native wrapper and a
     # published, self contained dotnet core directory tree to exist in the

--- a/chef-powershell/spec/integration/dll_integration_spec.rb
+++ b/chef-powershell/spec/integration/dll_integration_spec.rb
@@ -14,6 +14,10 @@
 # If CHEF_POWERSHELL_BIN is not set, the spec falls back to the gem's own bin/ruby_bin_folder
 # (useful when running from a fully-installed gem).
 
+require "bundler"
+require "open3"
+require "tempfile"
+
 # Snapshot CHEF_POWERSHELL_BIN *before* require "chef-powershell", because
 # powershell_exec.rb unconditionally overwrites it with the gem's own bin path
 # at module load time.
@@ -77,9 +81,9 @@ def raw_pwsh(script, timeout: -1)
   # nested runtime dir alongside the DLL -- register both explicitly. Do not
   # rely on System32 already having the VC++ redistributable.
   core_dir = File.dirname(NET10_DLL)
-  ChefPowerShell::Pwsh::Kernel32.SetDefaultDllDirectories(ChefPowerShell::Pwsh::Kernel32::LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)
-  [DLL_BIN_DIR, core_dir].each { |dir| ChefPowerShell::Pwsh::Kernel32.register_search_directory(dir) }
-  ChefPowerShell::Pwsh::Kernel32.SetDllDirectoryA(core_dir)
+  ChefPowerShell::Kernel32.SetDefaultDllDirectories(ChefPowerShell::Kernel32::LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)
+  [DLL_BIN_DIR, core_dir].each { |dir| ChefPowerShell::Kernel32.register_search_directory(dir) }
+  ChefPowerShell::Kernel32.SetDllDirectoryA(core_dir)
 
   ps = ChefPowerShell::Pwsh.allocate
   ps.instance_variable_set(:@powershell_dll, NET10_DLL)
@@ -359,5 +363,97 @@ RSpec.describe "DLL isolation", :windows_only do
     original = ENV["DOTNET_ROOT"]
     raw_pwsh("'test'")
     expect(ENV["DOTNET_ROOT"]).to eq(original)
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Regression: PowerShell#initialize must register its own DLL search directory
+# ---------------------------------------------------------------------------
+#
+# Background: AddDllDirectory/SetDefaultDllDirectories mutate GLOBAL,
+# PROCESS-WIDE Windows search-path state that is never unregistered. Because
+# this entire spec file runs in a single rspec process, a missing directory
+# registration in one interpreter's init path can be silently masked by
+# another interpreter's init path having already registered the very same
+# directory earlier in the run (raw_powershell/raw_pwsh above share DLL_BIN_DIR).
+#
+# This previously hid a real bug: PowerShell#initialize (the Windows
+# PowerShell / .NET Framework 4.8.1 path) never registered `bin_dir` as a DLL
+# search directory -- only Pwsh#exec (.NET 10 / PowerShell Core path) did.
+# Production usage (e.g. Chef-18) only ever constructs a `:powershell`
+# interpreter in a single-purpose process, so no such masking occurs there --
+# it failed with error 126 because the native CRT dependencies
+# (vcruntime140.dll, msvcp140.dll, etc.) could not be resolved.
+#
+# NOTE: on a dev/CI machine that already has the VC++ redistributable
+# installed under System32 (part of the classic DLL search order regardless
+# of AddDllDirectory registration), removing the registration call will NOT
+# reproduce the failure -- System32 quietly satisfies the dependency. The
+# behavioral spec below ("registers bin_dir...") is what actually catches a
+# regression deterministically, on any machine. This subprocess test instead
+# guards against the *masking* mechanism itself: it proves the real
+# constructor (not `.allocate`) succeeds end-to-end in a fresh, single-purpose
+# process with no possibility of state bleed from other examples in this
+# suite -- the same condition production code runs under.
+RSpec.describe "PowerShell#initialize DLL directory registration (process isolation)", :windows_only do
+  before(:all) do
+    skip "NET481 DLL not found at #{NET481_DLL}" unless File.exist?(NET481_DLL)
+  end
+
+  it "constructs ChefPowerShell::PowerShell and resolves native DLL dependencies in an otherwise-empty process" do
+    gem_root = File.expand_path("../..", __dir__)
+
+    script = <<~'RUBY'
+      require "chef-powershell"
+      result = ChefPowerShell::PowerShell.new("$PSVersionTable", timeout: -1)
+      raise "errors: #{result.errors}" unless result.errors.empty?
+      unless result.result["PSEdition"] == "Desktop"
+        raise "unexpected PSEdition: #{result.result["PSEdition"].inspect}"
+      end
+
+      puts "OK"
+    RUBY
+
+    env = { "CHEF_POWERSHELL_BIN" => DLL_BIN_DIR }
+
+    # Write the script to a real file rather than passing it via `ruby -e`.
+    # On Windows, `bundle` resolves to a .bat shim, so the OS re-invokes the
+    # child through cmd.exe -- which treats embedded newlines in a command-line
+    # argument as command separators and silently truncates a multi-line -e
+    # script at the first newline.
+    stdout, stderr, status = Tempfile.create(["dll_isolation_check", ".rb"]) do |file|
+      file.write(script)
+      file.close
+
+      Bundler.with_unbundled_env do
+        Open3.capture3(env, "bundle", "exec", "ruby", file.path, chdir: gem_root)
+      end
+    end
+
+    expect(status.success?).to be(true),
+      "subprocess failed (exit #{status.exitstatus}):\nSTDOUT:\n#{stdout}\nSTDERR:\n#{stderr}"
+    expect(stdout).to include("OK")
+  end
+
+  # Deterministic regression coverage: assert the actual Kernel32 calls happen,
+  # rather than relying on native DLL resolution failing -- which depends on
+  # whether the VC++ redistributable happens to already be installed on the
+  # machine running the suite (see NOTE above).
+  it "registers bin_dir as a DLL search directory before executing" do
+    orig_bin = ENV["CHEF_POWERSHELL_BIN"]
+    ENV["CHEF_POWERSHELL_BIN"] = DLL_BIN_DIR
+
+    allow(ChefPowerShell::Kernel32).to receive(:SetDefaultDllDirectories).and_call_original
+    allow(ChefPowerShell::Kernel32).to receive(:register_search_directory).and_call_original
+    allow(ChefPowerShell::Kernel32).to receive(:SetDllDirectoryA).and_call_original
+
+    ChefPowerShell::PowerShell.new("$PSVersionTable", timeout: -1)
+
+    expect(ChefPowerShell::Kernel32).to have_received(:SetDefaultDllDirectories)
+      .with(ChefPowerShell::Kernel32::LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)
+    expect(ChefPowerShell::Kernel32).to have_received(:register_search_directory).with(DLL_BIN_DIR)
+    expect(ChefPowerShell::Kernel32).to have_received(:SetDllDirectoryA).with(DLL_BIN_DIR)
+  ensure
+    ENV["CHEF_POWERSHELL_BIN"] = orig_bin
   end
 end

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -32,7 +32,6 @@ function Invoke-Build {
 
   $vsRoot = "$(Get-HabPackagePath visual-build-tools-2026)\Contents"
   $msbuildExe = "$vsRoot\MSBuild\Current\Bin\amd64\MSBuild.exe"
-  $vcTargetsPath = "$vsRoot\MSBuild\Microsoft\VC\v180\"
   $resolverDir = "$vsRoot\Common7\IDE\CommonExtensions\Microsoft\NuGet"
   $resolver = "$resolverDir\Microsoft.Build.NuGetSdkResolver.dll"
 
@@ -130,20 +129,19 @@ function Invoke-Build {
   Write-Output "MSBuild command: $msbuildExe"
   Write-Output "MSBuild project: $HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper.Core/Chef.Powershell.Wrapper.Core.vcxproj"
 
-  & $msbuildExe `
-    "$HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper.Core/Chef.Powershell.Wrapper.Core.vcxproj" `
-    /t:Build `
-    /p:Configuration=Release `
-    /p:Platform=x64 `
-    /p:BuildProjectReferences=false `
-    /p:VCTargetsPath="$vcTargetsPath" `
-    /p:DotNetSdkRoot="$env:DOTNET_ROOT" `
-    /p:DotNetCoreRefPackPath="$refPackPath" `
-    /p:IjwHostSourcePath="$ijwHostSourcePath" `
-    /p:DisableImplicitFrameworkReferences=true `
-    /p:GenerateRuntimeConfigurationFiles=false `
-    /nodeReuse:false `
-    /verbosity:diagnostic
+& $msbuildExe `
+  "$HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper.Core/Chef.Powershell.Wrapper.Core.vcxproj" `
+  /t:Build `
+  /p:Configuration=Release `
+  /p:Platform=x64 `
+  /p:BuildProjectReferences=false `
+  /p:DotNetSdkRoot="$env:DOTNET_ROOT" `
+  /p:DotNetCoreRefPackPath="$refPackPath" `
+  /p:IjwHostSourcePath="$ijwHostSourcePath" `
+  /p:DisableImplicitFrameworkReferences=true `
+  /p:GenerateRuntimeConfigurationFiles=false `
+  /nodeReuse:false `
+  /verbosity:diagnostic
 
   if ($LASTEXITCODE -ne 0) {
     throw "Chef.PowerShell.Wrapper.Core build failed with exit code $LASTEXITCODE"

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -21,43 +21,135 @@ function Invoke-SetupEnvironment {
 }
 
 function Invoke-Build {
-  Copy-Item $PLAN_CONTEXT/../* $HAB_CACHE_SRC_PATH/$pkg_dirname -recurse -force -Exclude ".vs"
-  nuget restore $HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell/packages.config -PackagesDirectory $HAB_CACHE_SRC_PATH/$pkg_dirname/packages -Source "https://www.nuget.org/api/v2"
-  MSBuild $HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper/Chef.Powershell.Wrapper.vcxproj /t:Build /p:Configuration=Release /p:Platform=x64
-  if($LASTEXITCODE -ne 0) {
-    Write-Error "dotnet build failed!"
-  }
+  Copy-Item $PLAN_CONTEXT/../* $HAB_CACHE_SRC_PATH/$pkg_dirname -Recurse -Force -Exclude ".vs"
+
+  nuget restore `
+    "$HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell/packages.config" `
+    -PackagesDirectory "$HAB_CACHE_SRC_PATH/$pkg_dirname/packages" `
+    -Source "https://www.nuget.org/api/v2"
 
   $env:DOTNET_ROOT = "$(Get-HabPackagePath dotnet-10-sdk)\bin"
 
-  # Step 1: Build the managed .NET 10 core library (CoreCLR). Must use dotnet — VC++ MSBuild
-  # tasks are .NET Framework-only and cannot build .csproj in the same invocation as .vcxproj.
-  & "$env:DOTNET_ROOT\dotnet.exe" build $HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Core/Chef.Powershell.Core.csproj --configuration Release /p:Platform=x64
-  if($LASTEXITCODE -ne 0) {
-    Write-Error "dotnet core build failed!"
-  }
+  $vsRoot = "$(Get-HabPackagePath visual-build-tools-2026)\Contents"
+  $msbuildExe = "$vsRoot\MSBuild\Current\Bin\amd64\MSBuild.exe"
+  $vcTargetsPath = "$vsRoot\MSBuild\Microsoft\VC\v180"
+  $resolverDir = "$vsRoot\Common7\IDE\CommonExtensions\Microsoft\NuGet"
+  $resolver = "$resolverDir\Microsoft.Build.NuGetSdkResolver.dll"
 
-  # Step 2: Build the C++/CLI wrapper with the 64-bit MSBuild.exe (.NET Framework).
-  # Must use amd64\MSBuild.exe — hostfxr.dll is 64-bit and cannot be loaded by a 32-bit process.
-  $vsBuildToolsPath = "$(Get-HabPackagePath visual-build-tools-2026)\Contents"
-  $vcTargetsPath = "$vsBuildToolsPath\MSBuild\Microsoft\VC\v180\"
-  $msbuildExe = "$vsBuildToolsPath\MSBuild\Current\Bin\amd64\MSBuild.exe"
-
-  # Locate the .NET 10 reference pack and host pack from the Hab dotnet-10-sdk package.
-  # These are passed to MSBuild so cl.exe and the linker can find the right binaries without
-  # relying on NuGet restore or workload resolution (both disabled via DisableImplicitFrameworkReferences).
   $refPackRoot = "$env:DOTNET_ROOT\packs\Microsoft.NETCore.App.Ref"
-  $refVersion = (Get-ChildItem $refPackRoot | Sort-Object Name -Descending | Select-Object -First 1).Name
+  $refVersion = (
+    Get-ChildItem $refPackRoot |
+      Sort-Object Name -Descending |
+      Select-Object -First 1
+  ).Name
   $refPackPath = "$refPackRoot\$refVersion\ref\net10.0"
-  $env:LIBPATH = "$refPackPath;$env:LIBPATH"
 
   $hostPackRoot = "$env:DOTNET_ROOT\packs\Microsoft.NETCore.App.Host.win-x64"
-  $hostPackVersion = (Get-ChildItem $hostPackRoot | Sort-Object Name -Descending | Select-Object -First 1).Name
+  $hostPackVersion = (
+    Get-ChildItem $hostPackRoot |
+      Sort-Object Name -Descending |
+      Select-Object -First 1
+  ).Name
   $ijwHostSourcePath = "$hostPackRoot\$hostPackVersion\runtimes\win-x64\native\ijwhost.dll"
-  & $msbuildExe $HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper.Core/Chef.Powershell.Wrapper.Core.vcxproj /t:Build /p:Configuration=Release /p:Platform=x64 /p:BuildProjectReferences=false /p:VCTargetsPath="$vcTargetsPath" /p:DotNetSdkRoot="$env:DOTNET_ROOT" /p:DotNetCoreRefPackPath="$refPackPath" /p:IjwHostSourcePath="$ijwHostSourcePath" /p:DisableImplicitFrameworkReferences=true /p:GenerateRuntimeConfigurationFiles=false /nodeReuse:false
-  if($LASTEXITCODE -ne 0) {
-    Write-Error "dotnet core build failed!"
+
+  Write-Output "*********************************************************************"
+  Write-Output "chef-powershell build diagnostics"
+  Write-Output "Visual Build Tools root: $vsRoot"
+  Write-Output "MSBuild: $msbuildExe"
+  Write-Output "Resolver directory: $resolverDir"
+  Write-Output "Resolver: $resolver"
+  Write-Output "Resolver exists: $(Test-Path $resolver)"
+  Write-Output "DOTNET_ROOT: $env:DOTNET_ROOT"
+  Write-Output "Reference pack: $refPackPath"
+  Write-Output "Reference pack exists: $(Test-Path $refPackPath)"
+  Write-Output "Host pack: $hostPackRoot\$hostPackVersion"
+  Write-Output "ijwhost.dll: $ijwHostSourcePath"
+  Write-Output "ijwhost.dll exists: $(Test-Path $ijwHostSourcePath)"
+  Write-Output "MSBuildSDKsPath: $env:MSBuildSDKsPath"
+  Write-Output "*********************************************************************"
+
+  if (-not (Test-Path $msbuildExe)) {
+    throw "MSBuild was not found: $msbuildExe"
   }
+
+  if (-not (Test-Path $resolver)) {
+    throw "NuGet SDK resolver was not found: $resolver"
+  }
+
+  if (-not (Test-Path $refPackPath)) {
+    throw ".NET 10 reference pack was not found: $refPackPath"
+  }
+
+  if (-not (Test-Path $ijwHostSourcePath)) {
+    throw "ijwhost.dll was not found: $ijwHostSourcePath"
+  }
+
+  Write-Output "NuGet resolver directory contents:"
+  Get-ChildItem $resolverDir |
+    Select-Object Name, Length, FullName
+
+  try {
+    [System.Reflection.Assembly]::LoadFrom($resolver) | Out-Null
+    Write-Output "Resolver loaded successfully"
+  }
+  catch {
+    Write-Error "Resolver failed to load"
+    Write-Error $_.Exception.ToString()
+    throw
+  }
+
+  Write-Output "Building .NET Framework PowerShell wrapper"
+
+  & $msbuildExe `
+    "$HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper/Chef.Powershell.Wrapper.vcxproj" `
+    /t:Build `
+    /p:Configuration=Release `
+    /p:Platform=x64 `
+    /nodeReuse:false `
+    /verbosity:minimal
+
+  if ($LASTEXITCODE -ne 0) {
+    throw "Chef.PowerShell.Wrapper build failed with exit code $LASTEXITCODE"
+  }
+
+  Write-Output "Building .NET 10 managed PowerShell core"
+
+  & "$env:DOTNET_ROOT\dotnet.exe" `
+    build `
+    "$HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Core/Chef.Powershell.Core.csproj" `
+    --configuration Release `
+    /p:Platform=x64
+
+  if ($LASTEXITCODE -ne 0) {
+    throw "Chef.Powershell.Core build failed with exit code $LASTEXITCODE"
+  }
+
+  $env:LIBPATH = "$refPackPath;$env:LIBPATH"
+
+  Write-Output "Building .NET 10 C++/CLI wrapper"
+  Write-Output "MSBuild command: $msbuildExe"
+  Write-Output "MSBuild project: $HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper.Core/Chef.Powershell.Wrapper.Core.vcxproj"
+
+  & $msbuildExe `
+    "$HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper.Core/Chef.Powershell.Wrapper.Core.vcxproj" `
+    /t:Build `
+    /p:Configuration=Release `
+    /p:Platform=x64 `
+    /p:BuildProjectReferences=false `
+    /p:VCTargetsPath="$vcTargetsPath" `
+    /p:DotNetSdkRoot="$env:DOTNET_ROOT" `
+    /p:DotNetCoreRefPackPath="$refPackPath" `
+    /p:IjwHostSourcePath="$ijwHostSourcePath" `
+    /p:DisableImplicitFrameworkReferences=true `
+    /p:GenerateRuntimeConfigurationFiles=false `
+    /nodeReuse:false `
+    /verbosity:diagnostic
+
+  if ($LASTEXITCODE -ne 0) {
+    throw "Chef.PowerShell.Wrapper.Core build failed with exit code $LASTEXITCODE"
+  }
+
+  Write-Output "chef-powershell native build completed successfully"
 }
 
 function Invoke-Install {

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -32,7 +32,7 @@ function Invoke-Build {
 
   $vsRoot = "$(Get-HabPackagePath visual-build-tools-2026)\Contents"
   $msbuildExe = "$vsRoot\MSBuild\Current\Bin\amd64\MSBuild.exe"
-  $vcTargetsPath = "$vsRoot\MSBuild\Microsoft\VC\v180"
+  $vcTargetsPath = "$vsRoot\MSBuild\Microsoft\VC\v180\"
   $resolverDir = "$vsRoot\Common7\IDE\CommonExtensions\Microsoft\NuGet"
   $resolver = "$resolverDir\Microsoft.Build.NuGetSdkResolver.dll"
 

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -21,7 +21,11 @@ function Invoke-SetupEnvironment {
 }
 
 function Invoke-Build {
-  Copy-Item $PLAN_CONTEXT/../* $HAB_CACHE_SRC_PATH/$pkg_dirname -Recurse -Force -Exclude ".vs"
+  Copy-Item $PLAN_CONTEXT/../* `
+    $HAB_CACHE_SRC_PATH/$pkg_dirname `
+    -Recurse `
+    -Force `
+    -Exclude ".vs"
 
   nuget restore `
     "$HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell/packages.config" `
@@ -61,7 +65,6 @@ function Invoke-Build {
   Write-Output "DOTNET_ROOT: $env:DOTNET_ROOT"
   Write-Output "Reference pack: $refPackPath"
   Write-Output "Reference pack exists: $(Test-Path $refPackPath)"
-  Write-Output "Host pack: $hostPackRoot\$hostPackVersion"
   Write-Output "ijwhost.dll: $ijwHostSourcePath"
   Write-Output "ijwhost.dll exists: $(Test-Path $ijwHostSourcePath)"
   Write-Output "MSBuildSDKsPath: $env:MSBuildSDKsPath"
@@ -97,6 +100,9 @@ function Invoke-Build {
     throw
   }
 
+  # Help MSBuild resolve NuGet resolver dependencies.
+  $env:PATH = "$resolverDir;$env:PATH"
+
   Write-Output "Building .NET Framework PowerShell wrapper"
 
   & $msbuildExe `
@@ -126,22 +132,22 @@ function Invoke-Build {
   $env:LIBPATH = "$refPackPath;$env:LIBPATH"
 
   Write-Output "Building .NET 10 C++/CLI wrapper"
-  Write-Output "MSBuild command: $msbuildExe"
-  Write-Output "MSBuild project: $HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper.Core/Chef.Powershell.Wrapper.Core.vcxproj"
+  Write-Output "MSBuild: $msbuildExe"
+  Write-Output "Project: $HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper.Core/Chef.Powershell.Wrapper.Core.vcxproj"
 
-& $msbuildExe `
-  "$HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper.Core/Chef.Powershell.Wrapper.Core.vcxproj" `
-  /t:Build `
-  /p:Configuration=Release `
-  /p:Platform=x64 `
-  /p:BuildProjectReferences=false `
-  /p:DotNetSdkRoot="$env:DOTNET_ROOT" `
-  /p:DotNetCoreRefPackPath="$refPackPath" `
-  /p:IjwHostSourcePath="$ijwHostSourcePath" `
-  /p:DisableImplicitFrameworkReferences=true `
-  /p:GenerateRuntimeConfigurationFiles=false `
-  /nodeReuse:false `
-  /verbosity:diagnostic
+  & $msbuildExe `
+    "$HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper.Core/Chef.Powershell.Wrapper.Core.vcxproj" `
+    /t:Build `
+    /p:Configuration=Release `
+    /p:Platform=x64 `
+    /p:BuildProjectReferences=false `
+    /p:DotNetSdkRoot="$env:DOTNET_ROOT" `
+    /p:DotNetCoreRefPackPath="$refPackPath" `
+    /p:IjwHostSourcePath="$ijwHostSourcePath" `
+    /p:DisableImplicitFrameworkReferences=true `
+    /p:GenerateRuntimeConfigurationFiles=false `
+    /nodeReuse:false `
+    /verbosity:diagnostic
 
   if ($LASTEXITCODE -ne 0) {
     throw "Chef.PowerShell.Wrapper.Core build failed with exit code $LASTEXITCODE"

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -135,6 +135,68 @@ function Invoke-Build {
   Write-Output "MSBuild: $msbuildExe"
   Write-Output "Project: $HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper.Core/Chef.Powershell.Wrapper.Core.vcxproj"
 
+  # Step 2: Build the C++/CLI wrapper with the 64-bit MSBuild.exe (.NET Framework).
+  # MSBuildSDKsPath must point at the installed .NET 10 SDK.
+  $vsBuildToolsPath = "$(Get-HabPackagePath visual-build-tools-2026)\Contents"
+  $msbuildExe = "$vsBuildToolsPath\MSBuild\Current\Bin\amd64\MSBuild.exe"
+
+  $sdkRoot = Join-Path $env:DOTNET_ROOT "Sdk"
+  $sdkVersion = (
+    Get-ChildItem $sdkRoot -Directory |
+      Sort-Object Name -Descending |
+      Select-Object -First 1
+  ).Name
+
+  $env:MSBuildSDKsPath = Join-Path $sdkRoot "$sdkVersion\Sdks"
+
+  # Locate the .NET 10 reference pack and host pack.
+  $refPackRoot = "$env:DOTNET_ROOT\packs\Microsoft.NETCore.App.Ref"
+  $refVersion = (
+    Get-ChildItem $refPackRoot -Directory |
+      Sort-Object Name -Descending |
+      Select-Object -First 1
+  ).Name
+  $refPackPath = "$refPackRoot\$refVersion\ref\net10.0"
+
+  $hostPackRoot = "$env:DOTNET_ROOT\packs\Microsoft.NETCore.App.Host.win-x64"
+  $hostPackVersion = (
+    Get-ChildItem $hostPackRoot -Directory |
+      Sort-Object Name -Descending |
+      Select-Object -First 1
+  ).Name
+  $ijwHostSourcePath = "$hostPackRoot\$hostPackVersion\runtimes\win-x64\native\ijwhost.dll"
+
+  Write-Output "Building .NET 10 C++/CLI wrapper"
+  Write-Output "MSBuild: $msbuildExe"
+  Write-Output "SDK root: $sdkRoot"
+  Write-Output "SDK version: $sdkVersion"
+  Write-Output "MSBuildSDKsPath: $env:MSBuildSDKsPath"
+  Write-Output "Reference pack: $refPackPath"
+  Write-Output "ijwhost.dll: $ijwHostSourcePath"
+  Write-Output "Microsoft.NET.Sdk exists: $(Test-Path (Join-Path $env:MSBuildSDKsPath 'Microsoft.NET.Sdk\Sdk'))"
+
+  if (-not (Test-Path $msbuildExe)) {
+    throw "MSBuild was not found: $msbuildExe"
+  }
+
+  if (-not (Test-Path $env:MSBuildSDKsPath)) {
+    throw "MSBuild SDK path was not found: $env:MSBuildSDKsPath"
+  }
+
+  if (-not (Test-Path (Join-Path $env:MSBuildSDKsPath "Microsoft.NET.Sdk\Sdk"))) {
+    throw "Microsoft.NET.Sdk was not found under: $env:MSBuildSDKsPath"
+  }
+
+  if (-not (Test-Path $refPackPath)) {
+    throw ".NET 10 reference pack was not found: $refPackPath"
+  }
+
+  if (-not (Test-Path $ijwHostSourcePath)) {
+    throw "ijwHost.dll was not found: $ijwHostSourcePath"
+  }
+
+  $env:LIBPATH = "$refPackPath;$env:LIBPATH"
+
   & $msbuildExe `
     "$HAB_CACHE_SRC_PATH/$pkg_dirname/Chef.Powershell.Wrapper.Core/Chef.Powershell.Wrapper.Core.vcxproj" `
     /t:Build `
@@ -146,6 +208,7 @@ function Invoke-Build {
     /p:IjwHostSourcePath="$ijwHostSourcePath" `
     /p:DisableImplicitFrameworkReferences=true `
     /p:GenerateRuntimeConfigurationFiles=false `
+    /p:EnableWorkloadResolver=false `
     /nodeReuse:false `
     /verbosity:diagnostic
 


### PR DESCRIPTION
<h2>Summary</h2>
<p>
Fixes a critical DLL-loading regression (Windows error 126) affecting the
Windows PowerShell (.NET Framework 4.8.1 / Desktop) execution path when run
against real Chef-18 installations. Also adds regression tests that would
have caught this bug, and closes the gap that let it slip through the
existing test suite.
</p>

<h2>JIRA Issue</h2>
<p>CHEF-37610</p>

<h2>Root Cause</h2>
<p>
Windows' default DLL search order used by FFI
(<code>LOAD_LIBRARY_SEARCH_DEFAULT_DIRS</code>) does <strong>not</strong>
include the directory containing the DLL being loaded, nor <code>PATH</code>,
nor the current working directory. It only searches the hosting EXE's
directory, <code>System32</code>, and any directories explicitly registered
via <code>AddDllDirectory</code>/<code>SetDllDirectory</code>.
</p>
<p>
<code>Chef.PowerShell.Wrapper.dll</code> depends on native VC++ runtime DLLs
(<code>vcruntime140.dll</code>, <code>msvcp140.dll</code>, etc.) that live
alongside it in the gem's <code>bin_dir</code>. The <code>Pwsh</code>
(.NET 10 / PowerShell Core) execution path already registered this directory
correctly in <code>Pwsh#exec</code>. However, the base <code>PowerShell</code>
class's <code>#initialize</code> (.NET Framework 4.8.1 / Windows PowerShell
Desktop path) never registered <code>bin_dir</code> as a search directory at
all.
</p>
<p>
On a target machine without the VC++ redistributable already present in
<code>System32</code> (such as the Chef-18 test environment where this was
discovered), the wrapper DLL loaded fine via its absolute path, but its
dependent native DLLs could not be resolved &mdash; producing error 126.
</p>

<h2>Why Existing Tests Didn't Catch This</h2>
<ul>
  <li>
    The integration test helper for the Desktop path
    (<code>raw_powershell</code>) used
    <code>ChefPowerShell::PowerShell.allocate</code> plus manual instance
    variable injection to bypass gem path resolution &mdash; which also
    bypassed <code>#initialize</code> entirely, the exact method containing
    the bug.
  </li>
  <li>
    <code>AddDllDirectory</code>/<code>SetDefaultDllDirectories</code> mutate
    <strong>global, process-wide</strong> Windows search-path state that is
    never unregistered. Because the whole rspec suite runs in a single Ruby
    process, earlier <code>Pwsh</code>-path tests had already registered the
    same physical directory used by the Desktop-path DLLs, silently masking
    the missing registration.
  </li>
  <li>
    Dev/CI machines often already have the VC++ redistributable installed
    under <code>System32</code> (verified on this workstation), which
    satisfies the dependency regardless of whether the directory was
    registered &mdash; so even a naive "does it run" test can pass while the
    underlying registration bug is still present.
  </li>
</ul>

<h2>Changes Made</h2>
<ul>
  <li>
    Relocated the shared <code>Kernel32</code> FFI module (
    <code>SetDllDirectoryA</code>, <code>SetDefaultDllDirectories</code>,
    <code>AddDllDirectory</code>, <code>register_search_directory</code>)
    from being duplicated/nested under <code>Pwsh</code> to a single shared
    definition directly under <code>ChefPowerShell</code> in
    <code>lib/chef-powershell/powershell.rb</code>.
  </li>
  <li>
    Added DLL search directory registration to <code>PowerShell#initialize</code>
    (mirroring the pattern already used in <code>Pwsh#exec</code>): calls
    <code>SetDefaultDllDirectories</code>, then
    <code>register_search_directory(bin_dir)</code> (raising
    <code>LoadError</code> on failure), then <code>SetDllDirectoryA(bin_dir)</code>
    as defense-in-depth for older Windows versions &mdash; before invoking
    <code>exec</code>.
  </li>
  <li>
    Removed the now-duplicate <code>Kernel32</code> module from
    <code>lib/chef-powershell/pwsh.rb</code>. All bare <code>Kernel32.*</code>
    references throughout the codebase (<code>pwsh.rb</code>,
    <code>smoke_test_dlls.rb</code>, <code>verify_hab_build.rb</code>)
    continue to resolve correctly via Ruby lexical scoping with no further
    changes required.
  </li>
  <li>
    Updated fully-qualified references in
    <code>spec/integration/dll_integration_spec.rb</code> from
    <code>ChefPowerShell::Pwsh::Kernel32</code> to
    <code>ChefPowerShell::Kernel32</code>.
  </li>
</ul>

<h2>New Regression Tests</h2>
<p>
Added two tests to <code>spec/integration/dll_integration_spec.rb</code> under
<code>"PowerShell#initialize DLL directory registration (process isolation)"</code>:
</p>
<ul>
  <li>
    <strong>Subprocess isolation test:</strong> spawns a fresh, single-purpose
    Ruby process (script written to a temp file, executed via
    <code>Open3.capture3</code>) that calls the real
    <code>ChefPowerShell::PowerShell.new</code> constructor &mdash; reproducing
    the exact single-purpose-process condition production code runs under,
    with no possibility of state bleed from other examples in the suite.
  </li>
  <li>
    <strong>Deterministic spy-based test:</strong> stubs
    <code>ChefPowerShell::Kernel32</code> with <code>and_call_original</code>
    and asserts <code>SetDefaultDllDirectories</code>,
    <code>register_search_directory(bin_dir)</code>, and
    <code>SetDllDirectoryA(bin_dir)</code> are actually invoked during
    <code>PowerShell.new</code>. Unlike the subprocess test, this does not
    depend on whether the VC++ redistributable happens to already be present
    on the machine running the suite &mdash; verified by temporarily reverting
    the fix and confirming this test fails deterministically, then restoring
    the fix and confirming it passes.
  </li>
</ul>

<h2>Testing</h2>
<ul>
  <li>Full rspec suite: <strong>68 examples, 0 failures</strong> (66 pre-existing + 2 new).</li>
  <li>Cookstyle/chefstyle lint: no offenses on modified files.</li>
  <li>Verified the new spy-based test fails deterministically when the fix is reverted, and passes with the fix restored, confirming it provides real regression coverage.</li>
</ul>

<h2>AI Assistance</h2>
<p>This work was completed with AI assistance following Progress AI policies.</p>